### PR TITLE
Make transport-belt-capacity research unique

### DIFF
--- a/secretas/prototypes/technology.lua
+++ b/secretas/prototypes/technology.lua
@@ -172,7 +172,7 @@ data:extend({
 
     {
       type = "technology",
-      name = "transport-belt-capacity-3",
+      name = "transport-belt-capacity-3-secretas",
       localised_description = {"technology-description.belt-capacity"},
       icons = util.technology_icon_constant_stack_size("__space-age__/graphics/technology/transport-belt-capacity.png"),
       effects =


### PR DESCRIPTION
This makes the belt capacity update not collide with infinite belt stacking mods like:
 [infinite belt stacking](https://github.com/notnotmelon/infinite-belt-stacking/blob/2ba45ac5e0e5e32dc15742d69a493e4b1185aaaf/data.lua#L37)