### PR TITLE
Fix cross mod compatibility with adding all sciences to end game science prod research

### DIFF
--- a/secretas/data-final-fixes.lua
+++ b/secretas/data-final-fixes.lua
@@ -1,0 +1,30 @@
+local util_scripts = require("scripts")
+
+-- log("** before modification:")
+-- log(serpent.block(data.raw['technology']["science-pack-productivity"].effects))
+
+for _, science_pack in pairs(util_scripts.get_all_science_from_all_labs()) do
+	--log("**testing science: " .. science_pack)
+	if(not util_scripts.table_contains(data.raw['technology']["science-pack-productivity"].effects, science_pack, "recipe")) then
+		for _, recipe in pairs(data.raw['recipe']) do
+			if(recipe.results and util_scripts.table_contains(recipe.results, science_pack, "name")) then
+				local insert_science = {
+					type = "change-recipe-productivity",
+					recipe = recipe.name,
+					change = 0.01
+				}
+				table.insert(data.raw['technology']["science-pack-productivity"].effects, insert_science)
+			end
+		end
+	end
+	if(not util_scripts.table_contains(data.raw['technology']["science-pack-productivity"].unit.ingredients, science_pack, 1)) then
+			local insert_ingredients = {science_pack, 1}
+			table.insert(data.raw['technology']["science-pack-productivity"].unit.ingredients,insert_ingredients)
+	end
+	if(not util_scripts.table_contains(data.raw['lab']['biolab'].inputs, science_pack)) then
+		table.insert(data.raw['lab']['biolab'].inputs, science_pack)
+	end
+end
+
+-- log("**biolab inputs:")
+-- log(serpent.block(data.raw['lab']['biolab'].inputs))

--- a/secretas/data-updates.lua
+++ b/secretas/data-updates.lua
@@ -5,25 +5,3 @@ for k,v in pairs(all_lab_types) do
 end
 
 data.raw['furnace']['recycler'].result_inventory_size = 40
-
-local all_packs = data.raw['tool']
---log("all_packs=")
---log(serpent.block(all_packs))
-for k,v in pairs(all_packs) do
-    if(v.subgroup == "science-pack") then
-        
-        
-        if(data.raw["recipe"][v.name] ~= nil and v.name ~= "automation-science-pack" and v.name ~= "logistic-science-pack" and v.name ~= "chemical-science-pack" and v.name ~= "military-science-pack" and v.name ~= "production-science-pack" and v.name ~= "utility-science-pack" and v.name ~= "space-science-pack" and v.name ~= "metallurgic-science-pack"  and v.name ~= "electromagnetic-science-pack"  and v.name ~= "agricultural-science-pack"  and v.name ~= "cryogenic-science-pack"  and v.name ~= "golden-science-pack"  and v.name ~= "promethium-science-pack" ) then
-            local insert_science =         {
-                type = "change-recipe-productivity",
-                recipe = v.name,
-                change = 0.01
-            }
-            local insert_ingredients = {v.name, 1}
-            
-            table.insert(data.raw['technology']["science-pack-productivity"].effects,insert_science)
-            table.insert(data.raw['technology']["science-pack-productivity"].unit.ingredients,insert_ingredients)
-        end
-    end
-end
-

--- a/secretas/scripts.lua
+++ b/secretas/scripts.lua
@@ -1,0 +1,33 @@
+local util_scripts = {}
+
+util_scripts.table_contains = function (table, value, key)
+	-- log("table_contains:")
+	-- log("**table")
+	-- log(serpent.block(table))
+	-- log("**value")
+	-- log(serpent.block(value))
+	-- log("**key")
+	-- log(serpent.block(key))
+	for i, localVal in ipairs(table) do
+			if(key ~= nil and localVal[key] == value or localVal == value) then
+					return true
+			end
+	end
+	return false
+end
+
+util_scripts.get_all_science_from_all_labs = function ()
+	local all_science = {}
+	for _, lab in pairs(data.raw['lab']) do
+			for __, lab_input in pairs(lab.inputs) do
+					if(not table_contains(all_science, lab_input)) then
+							table.insert(all_science, lab_input)
+					end
+			end
+	end
+	-- log("**all_science:")
+	-- log(serpent.block(all_science))
+	return all_science
+end
+
+return util_scripts


### PR DESCRIPTION
Fixes https://github.com/ZacharyDK/Secretas/issues/4

This was surprisingly tricky to get it working well, but hey there is now more likely to be all sciences from every mod on that last tech, and without breaking anything either.

I've opted to add all possible science packs to the Biolab to fix the crash, but while I was at it barely even half of the science packs in my modpack were actually added anyway, so I've also improved that a lot.

There still seems to be a minor variation in my mod collection between if(v.subgroup == "science-pack") then vs my new util_scripts.get_all_science_from_all_labs() which I intend to figure out, so I might make another PR once I have time to figure that out, but until then the current state of this PR should still be a major improvement.