### PR TITLE
dea dia compatibility

### DIFF
--- a/secretas/control.lua
+++ b/secretas/control.lua
@@ -1,0 +1,45 @@
+
+if script.active_mods["dea-dia-system"] then
+    -- dea dia does not want to, or need to know about what tile this surface needs a replacement for,
+    -- so we include the normal paltform cleaning code here.
+    local function mine_collector(entity, player)
+        local platform_radius = remote.call("dea_dia_system", "platform_radius")
+        local position = entity.position
+        local surface = entity.surface
+        -- reset the surface tiles
+        if entity.surface.name == "secretas" then
+            local tiles = {}
+            for x = position.x - platform_radius, position.x + platform_radius do
+                for y = position.y - platform_radius, position.y + platform_radius do
+                    table.insert(tiles, #tiles + 1, {
+                        position = { x = x, y = y },
+                        name = "secretas-surface"
+                    })
+                end
+            end
+            surface.set_tiles(tiles, true, false, true, false)
+        end
+    end
+
+
+    script.on_event(defines.events.on_entity_died, function(event)
+        mine_collector(event.entity)
+    end, { {
+        filter = "name",
+        name = "gas-collector-roboport"
+    } })
+
+    script.on_event(defines.events.on_player_mined_entity, function(event)
+        mine_collector(event.entity, event.player)
+    end, { {
+        filter = "name",
+        name = "gas-collector-roboport"
+    } })
+
+    script.on_event(defines.events.on_robot_mined_entity, function(event)
+        mine_collector(event.entity)
+    end, { {
+        filter = "name",
+        name = "gas-collector-roboport"
+    } })
+end

--- a/secretas/data-updates.lua
+++ b/secretas/data-updates.lua
@@ -6,3 +6,13 @@ end
 
 data.raw['furnace']['recycler'].result_inventory_size = 40
 --data.raw["utility-constants"]["default"].max_belt_stack_size = 5
+
+
+-- fix the gas giant resource patches so they can be placed on secretas.
+if mods["dea-dia-system"] then
+    for _,resource in pairs(data.raw["resource"]) do
+        if resource.category == "gas-giant" then
+            table.insert(resource.autoplace.tile_restriction,"secretas-surface")
+        end
+    end
+end

--- a/secretas/graphics/planet/orbit-frozeta.png
+++ b/secretas/graphics/planet/orbit-frozeta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1641e601c38be3bba091dd41938df221d5ce45e9465d8e9c84b744bbb1dadb09
+size 51796

--- a/secretas/graphics/technology/frozeta-discovery.png
+++ b/secretas/graphics/technology/frozeta-discovery.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1056d699c6920823fa22a64bed6dc2b488ad9300a2f1af19d8f583b1665faa2
+size 64943

--- a/secretas/graphics/terrain/secretas-surface.png
+++ b/secretas/graphics/terrain/secretas-surface.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:406c6c5aed313314360cfb815eaef8d9892673418a7c717a354fed811b1f1af0
+size 558

--- a/secretas/info.json
+++ b/secretas/info.json
@@ -6,7 +6,8 @@
     "factorio_version": "2.0",
     "dependencies": ["base >= 2.0",
         "space-age >= 2.0",
-        "quality >= 2.0"
+        "quality >= 2.0",
+        "PlanetsLib"
     ],
     "space_travel_required": true,
     "description": "○🌐This mod adds Secretas and Frotzeta. Secretas is a gas giant. Frozeta is one of its planet sized moon. Frozeta is challenge planet - recycle spaceship scrap - like an ugly love child of Fulgora and Aquilo"

--- a/secretas/locale/en/secretas.cfg
+++ b/secretas/locale/en/secretas.cfg
@@ -78,7 +78,8 @@ gold-plate-production-alt=Gold Plate Furnace Smelting
 golden-egg=Golden Biter Egg
 
 [technology-name]
-planet-discovery-secretas=Planet discovery Secretas
+planet-discovery-secretas=Planet discovery Frozeta
+planet-discovery-gas-giant-secretas=Planet discovery Secretas
 hyper-inserter=Hyper inserter
 spaceship-scrap-recycling-productivity=Spaceship scrap recycling productivity
 science-pack-productivity=Science pack productivity
@@ -93,8 +94,6 @@ worker-robots-storage-7=Worker robots cargo size 7
 worker-robots-storage-8=Worker robots cargo size 8
 worker-robots-storage-9=Worker robots cargo size 9
 gold-plate-productivity=Gold-plate-productivity
-
-
 
 
 [technology-description]

--- a/secretas/prototypes/planet/frozeta-map-gen.lua
+++ b/secretas/prototypes/planet/frozeta-map-gen.lua
@@ -1,4 +1,5 @@
-local planet_map_gen = require("__space-age__/prototypes/planet/planet-map-gen")
+local planet_map_gen = require("__secretas__/prototypes/planet/secretas-map-gen")
+
 
 planet_map_gen.frozeta = function() --TODO add all my decorations.
     return

--- a/secretas/prototypes/planet/planet.lua
+++ b/secretas/prototypes/planet/planet.lua
@@ -6,120 +6,208 @@ local effects = require("__core__.lualib.surface-render-parameter-effects")
 local asteroid_util = require("__secretas__.prototypes.planet.asteroid-spawn-definitions")
 local space_age_asteroid_util = require("__space-age__.prototypes.planet.asteroid-spawn-definitions")
 
-data:extend(
-{
-    {
-        type = "space-location",
-        name = "secretas",
-        icon = "__secretas__/graphics/icons/secretas-icon.png",
-        starmap_icon = "__secretas__/graphics/planet/starmap-secretas.png",
-        starmap_icon_size = 512,
-        order = "h[secretas]",
-        subgroup = "planets",
-        gravity_pull = 40,
-        distance = 45,
-        orientation = 0.18,
-        magnitude = 3.0,
-        label_orientation = 0.0,
-        asteroid_spawn_influence = 1,
-        auto_save_on_first_trip = true,
-        asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge, 0.9) --TODO define golden asteroids
+local secretas = {
+  type = "space-location",
+  name = "secretas",
+  icon = "__secretas__/graphics/icons/secretas-icon.png",
+  starmap_icon = "__secretas__/graphics/planet/starmap-secretas.png",
+  starmap_icon_size = 512,
+  order = "h[secretas]",
+  subgroup = "planets",
+  gravity_pull = 40,
+  distance = 45,
+  orientation = 0.18,
+  magnitude = 3.0,
+  label_orientation = 0.0,
+  asteroid_spawn_influence = 1,
+  auto_save_on_first_trip = true,
+  asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge, 0.9) --TODO define golden asteroids
+}
+
+-- if dea dia is not present, then secretas is a sprite instead of a real location.
+-- if it is present, then use the gas giant elements from that mod to create a usable surface for secretas
+if mods["dea-dia-system"] == nil then
+  secretas.sprite_only = true
+else
+  secretas.type = "planet"
+  secretas.map_gen_settings = planet_map_gen.secretas() --TODO
+  secretas.platform_procession_set = {
+    arrival = {
+      "planet-to-platform-b"
     },
-    {
-        type = "planet",
-        name = "frozeta",
-        icon = "__secretas__/graphics/icons/frozeta.png",
-        starmap_icon = "__secretas__/graphics/planet/starmap-frozeta.png",
-        starmap_icon_size = 512,
-        gravity_pull = 10,
-        distance = 44,
-        orientation = 0.20,
-        magnitude = 0.8,
-        label_orientation = 0.15,
-        order = "f[frozeta]",
-        subgroup = "planets",
-        map_gen_settings = planet_map_gen.frozeta(), --TODO
-        pollutant_type = nil,
-        solar_power_in_space = 30,
-        platform_procession_set =
+    departure = {
+      "platform-to-planet-a"
+    }
+  }
+  secretas.planet_procession_set = {
+    arrival = {
+      "platform-to-planet-b"
+    },
+    departure = {
+      "planet-to-platform-a"
+    }
+  }
+  secretas.procession_graphic_catalogue = planet_catalogue_aquilo
+  secretas.surface_properties =
+  {
+    ["day-night-cycle"] = 30 * minute,
+    ["magnetic-field"] = 99,
+    pressure = 1500,
+    ["solar-power"] = 1
+  }
+  secretas.persistent_ambient_sounds =
         {
-          arrival = {"planet-to-platform-b"},
-          departure = {"platform-to-planet-a"}
-        },
-        planet_procession_set =
-        {
-          arrival = {"platform-to-planet-b"},
-          departure = {"planet-to-platform-a"}
-        },
-        procession_graphic_catalogue = planet_catalogue_aquilo,
-        surface_properties =
-        {
-          ["day-night-cycle"] = 20 * minute,
-          ["magnetic-field"] = 10,
-          pressure = 280,
-          ["solar-power"] = 1,
-          gravity = 10
-        },
-        asteroid_spawn_influence = 1,
-        asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas, 0.9), --TODO adjust
-        persistent_ambient_sounds =
-        {
-          base_ambience = {filename = "__space-age__/sound/wind/base-wind-aquilo.ogg", volume = 0.5},
-          wind = {filename = "__space-age__/sound/wind/wind-aquilo.ogg", volume = 0.8},
-          crossfade =
-          {
-            order = {"wind", "base_ambience"},
-            curve_type = "cosine",
-            from = {control = 0.35, volume_percentage = 0.0},
-            to = {control = 2, volume_percentage = 100.0}
-          },
-          semi_persistent =
-          {
+            base_ambience = { filename = "__space-age__/sound/wind/base-wind-aquilo.ogg", volume = 0.5 },
+            wind = { filename = "__space-age__/sound/wind/wind-aquilo.ogg", volume = 0.8 },
+            crossfade =
             {
-              sound =
-              {
-                variations = sound_variations("__space-age__/sound/world/semi-persistent/ice-cracks", 5, 0.7),
-                advanced_volume_control =
-                {
-                  fades = {fade_in = {curve_type = "cosine", from = {control = 0.5, volume_percentage = 0.0}, to = {2, 100.0}}}
-                }
-              },
-              delay_mean_seconds = 10,
-              delay_variance_seconds = 5
+                order = { "wind", "base_ambience" },
+                curve_type = "cosine",
+                from = { control = 0.35, volume_percentage = 0.0 },
+                to = { control = 2, volume_percentage = 100.0 }
             },
+            semi_persistent =
             {
-              sound = {variations = sound_variations("__space-age__/sound/world/semi-persistent/cold-wind-gust", 5, 0.3)},
-              delay_mean_seconds = 15,
-              delay_variance_seconds = 9
+                {
+                    sound = { variations = sound_variations("__space-age__/sound/world/semi-persistent/cold-wind-gust", 5, 0.3) },
+                    delay_mean_seconds = 15,
+                    delay_variance_seconds = 9
+                }
             }
+        }
+       secretas.surface_render_parameters = {
+          fog = {
+              color1 = {
+                  0.13,
+                  0.32,
+                  0.48,
+                  1
+              },
+              color2 = {
+                  0.5,
+                  0.11,
+                  0.18,
+                  1
+              },
+              detail_noise_texture = {
+                  filename = "__core__/graphics/clouds-detail-noise.png",
+                  size = 2048
+              },
+              shape_noise_texture = {
+                  filename = "__core__/graphics/clouds-noise.png",
+                  size = 2048
+              }
           }
-        },
-        entities_require_heating = true,
-        player_effects =
-        {
-          type = "direct",
-          action_delivery =
-          {
-            type = "instant",
-            source_effects =
-            {
-              type = "create-trivial-smoke",
-              smoke_name = "aquilo-snow-smoke",
-              speed = {0, 0.1},
-              initial_height = 0.5,
-              speed_multiplier = 1,
-              speed_multiplier_deviation = 0.5,
-              starting_frame = 8,
-              starting_frame_deviation = 8,
-              offset_deviation = {{-96, -48}, {96, 48}},
-              speed_from_center = 0.04,
-              speed_from_center_deviation = 0.2
-            }
-          }
-        },
-        ticks_between_player_effects = 2
+      }
+end
+
+
+data:extend({ secretas })
+
+PlanetsLib:extend { {
+  type = "planet",
+  name = "frozeta",
+  icon = "__secretas__/graphics/icons/frozeta.png",
+  starmap_icon = "__secretas__/graphics/planet/starmap-frozeta.png",
+  starmap_icon_size = 512,
+  gravity_pull = 10,
+  orbit = {
+    parent = secretas,
+    distance = 5,
+    orientation = 0.50,
+    sprite = {
+      type = "sprite",
+      filename = "__secretas__/graphics/planet/orbit-frozeta.png",
+      size = 1283,
+      scale = 0.25,
+    }
+  },
+  magnitude = 0.8,
+  label_orientation = 0.15,
+  order = "f[frozeta]",
+  subgroup = "planets",
+  map_gen_settings = planet_map_gen.frozeta(), --TODO
+  pollutant_type = nil,
+  solar_power_in_space = 30,
+  platform_procession_set =
+  {
+    arrival = { "planet-to-platform-b" },
+    departure = { "platform-to-planet-a" }
+  },
+  planet_procession_set =
+  {
+    arrival = { "platform-to-planet-b" },
+    departure = { "planet-to-platform-a" }
+  },
+  procession_graphic_catalogue = planet_catalogue_aquilo,
+  surface_properties =
+  {
+    ["day-night-cycle"] = 20 * minute,
+    ["magnetic-field"] = 10,
+    pressure = 280,
+    ["solar-power"] = 1,
+    gravity = 10
+  },
+  asteroid_spawn_influence = 1,
+  asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas, 0.9), --TODO adjust
+  persistent_ambient_sounds =
+  {
+    base_ambience = { filename = "__space-age__/sound/wind/base-wind-aquilo.ogg", volume = 0.5 },
+    wind = { filename = "__space-age__/sound/wind/wind-aquilo.ogg", volume = 0.8 },
+    crossfade =
+    {
+      order = { "wind", "base_ambience" },
+      curve_type = "cosine",
+      from = { control = 0.35, volume_percentage = 0.0 },
+      to = { control = 2, volume_percentage = 100.0 }
     },
-    --[[
+    semi_persistent =
+    {
+      {
+        sound =
+        {
+          variations = sound_variations("__space-age__/sound/world/semi-persistent/ice-cracks", 5, 0.7),
+          advanced_volume_control =
+          {
+            fades = { fade_in = { curve_type = "cosine", from = { control = 0.5, volume_percentage = 0.0 }, to = { 2, 100.0 } } }
+          }
+        },
+        delay_mean_seconds = 10,
+        delay_variance_seconds = 5
+      },
+      {
+        sound = { variations = sound_variations("__space-age__/sound/world/semi-persistent/cold-wind-gust", 5, 0.3) },
+        delay_mean_seconds = 15,
+        delay_variance_seconds = 9
+      }
+    }
+  },
+  entities_require_heating = true,
+  player_effects =
+  {
+    type = "direct",
+    action_delivery =
+    {
+      type = "instant",
+      source_effects =
+      {
+        type = "create-trivial-smoke",
+        smoke_name = "aquilo-snow-smoke",
+        speed = { 0, 0.1 },
+        initial_height = 0.5,
+        speed_multiplier = 1,
+        speed_multiplier_deviation = 0.5,
+        starting_frame = 8,
+        starting_frame_deviation = 8,
+        offset_deviation = { { -96, -48 }, { 96, 48 } },
+        speed_from_center = 0.04,
+        speed_from_center_deviation = 0.2
+      }
+    }
+  },
+  ticks_between_player_effects = 2
+},
+  --[[
     {
         type = "space-connection",
         name = "gleba-secretas",
@@ -131,36 +219,40 @@ data:extend(
         asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge)
     },
     --]]
-    {
-        type = "space-connection",
-        name = "aquilo-secretas",
-        subgroup = "planet-connections",
-        from = "aquilo",
-        to = "secretas",
-        order = "k",
-        length = 80000,
-        asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas)
-    },
-    {
-        type = "space-connection",
-        name = "secretas-edge",
-        subgroup = "planet-connections",
-        from = "secretas",
-        to = "solar-system-edge",
-        order = "l",
-        length = 20000,
-        asteroid_spawn_definitions = space_age_asteroid_util.spawn_definitions(space_age_asteroid_util.aquilo_solar_system_edge) --Not sure why mine leads to an index error
-    },
-    {
-      type = "space-connection",
-      name = "secretas-frozeta",
-      subgroup = "planet-connections",
-      from = "secretas",
-      to = "frozeta",
-      order = "o",
-      length = 10000,
-      asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas)
-    },
-
 }
-)
+data:extend({ {
+  type = "space-connection",
+  name = "aquilo-frozeta",
+  subgroup = "planet-connections",
+  from = "aquilo",
+  to = "frozeta",
+  order = "k",
+  length = 80000,
+  asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas)
+},
+  {
+    type = "space-connection",
+    name = "frozeta-edge",
+    subgroup = "planet-connections",
+    from = "frozeta",
+    to = "solar-system-edge",
+    order = "l",
+    length = 20000,
+    asteroid_spawn_definitions = space_age_asteroid_util.spawn_definitions(space_age_asteroid_util
+      .aquilo_solar_system_edge) --Not sure why mine leads to an index error
+  }
+
+})
+
+if mods["dea-dia-system"] then
+  data:extend({ {
+    type = "space-connection",
+    name = "secretas-frozeta",
+    subgroup = "planet-connections",
+    from = "secretas",
+    to = "frozeta",
+    order = "k",
+    length = 80000,
+    asteroid_spawn_definitions = asteroid_util.spawn_definitions(asteroid_util.aquilo_secretas)
+  } })
+end

--- a/secretas/prototypes/planet/secretas-map-gen.lua
+++ b/secretas/prototypes/planet/secretas-map-gen.lua
@@ -1,0 +1,41 @@
+local planet_map_gen = require("__space-age__/prototypes/planet/planet-map-gen")
+
+
+planet_map_gen.secretas = function ()
+    local map_gen_setting = table.deepcopy(data.raw.planet.nauvis.map_gen_settings)
+
+    map_gen_setting.property_expression_names = {}
+
+    map_gen_setting.autoplace_controls = {    }
+
+    map_gen_setting.autoplace_settings["tile"] = {
+        settings =
+        {
+            ["secretas-surface"] = {},
+        }
+    }
+    map_gen_setting.autoplace_settings["decorative"] = {
+        -- when this was made, dea dia only had one decorative type.
+        settings = {
+            ["gas-giant-cloud-1"] = {},
+            ["gas-giant-cloud-2"] = {},
+            ["gas-giant-cloud-3"] = {}
+        }
+    }
+    map_gen_setting.cliff_settings = nil
+    map_gen_setting.autoplace_settings["entity"] = {
+        -- a limited set of resources that are still useful together.
+        -- with imported holmium, it allows for fusion cells to be made.
+        settings = {
+            ["fluorine-wind"] = {},
+            ["ammonia-wind"] = {},
+            ["lithium-wind"] = {},
+            -- this type is not used by dea dia, will be kept 
+            ["high-temperature-wind"] = {}
+        }
+    }
+
+    return map_gen_setting
+end
+
+return planet_map_gen

--- a/secretas/prototypes/technology.lua
+++ b/secretas/prototypes/technology.lua
@@ -5,16 +5,11 @@ data:extend({
     {
         type = "technology",
         name = "planet-discovery-secretas",
-        icons = util.technology_icon_constant_planet("__secretas__/graphics/technology/secretas-discovery.png"),
+        icons = util.technology_icon_constant_planet("__secretas__/graphics/technology/frozeta-discovery.png"),
         icon_size = 256,
         essential = true,
         effects =
         {
-            {
-                type = "unlock-space-location",
-                space_location = "secretas",
-                use_icon_overlay_constant = true
-            },
             {
                 type = "unlock-space-location",
                 space_location = "frozeta",
@@ -568,3 +563,44 @@ data:extend({
 
 }
 )
+
+if mods["dea-dia-system"] then
+  
+  data:extend{{
+    type = "technology",
+    name = "planet-discovery-gas-giant-secretas",
+    icons = util.technology_icon_constant_planet("__secretas__/graphics/technology/secretas-discovery.png"),
+    icon_size = 256,
+    essential = true,
+    effects =
+    {
+        {
+            type = "unlock-space-location",
+            space_location = "secretas",
+            use_icon_overlay_constant = true
+        },
+    },
+    prerequisites = {"planet-discovery-secretas", "planet-discovery-dea-dia"},
+    unit =
+    {
+      count = 3000,
+      ingredients =
+      {
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1},
+        {"production-science-pack", 1},
+        {"utility-science-pack", 1},
+        {"space-science-pack", 1},
+        {"metallurgic-science-pack", 1},
+        {"agricultural-science-pack", 1},
+        {"electromagnetic-science-pack", 1},
+        {"cryogenic-science-pack", 1},
+        {"golden-science-pack", 1},
+        {"aerospace-science-pack", 1},
+      },
+      time = 60
+    }
+}}
+
+end

--- a/secretas/prototypes/tile/secretas.lua
+++ b/secretas/prototypes/tile/secretas.lua
@@ -1,0 +1,36 @@
+local secretas_surface = table.deepcopy(data.raw["tile"]["empty-space"])
+
+secretas_surface.name = "secretas-surface"
+secretas_surface.effect = nil
+secretas_surface.map_color = {
+    0.13, 0.32, 0.48, 1.0
+}
+secretas_surface.fluid = "steam"
+
+secretas_surface.collision_mask = {
+    layers = {
+        floor = true,
+        player = true,
+        water_tile = true,
+        rail = true,
+        rail_support = true,
+        -- this layer is from dea dia.
+        ["gas-giant-surface"] = true
+    }
+}
+
+secretas_surface.destroys_dropped_items = true
+secretas_surface.variants = {
+    empty_transitions = true,
+    main = {
+        {
+            count = 1,
+            picture = "__secretas__/graphics/terrain/secretas-surface.png",
+            size = 1
+        }
+    }
+}
+
+data:extend{
+    secretas_surface
+}

--- a/secretas/prototypes/tile/tiles.lua
+++ b/secretas/prototypes/tile/tiles.lua
@@ -231,3 +231,8 @@ data:extend
         trigger_effect = tile_trigger_effects.stone_path_trigger_effect()
     },
 }
+
+--include the tile for secretas when dea dia is installed.
+if mods["dea-dia-system"] then
+  require("prototypes.tile.secretas")
+end


### PR DESCRIPTION
Secretas now uses dea dia as a template to get a surface going.

The changes:
- All space connections go into frozeta instead of secretas (this is to ensure that the map does not need to be redrawn, ever)
- If dea dia is not installed, secretas turns into a display only sprite, because we don't need the location anymore. (I can remove this, this is just as a cleanup to remove an otherwise empty space connection)
- Frozeta now has a proper orbit graphic around secretas
- The discovery tech is split in two, just so I can properly gate Secretas behind the technologies it now needs without blocking frozeta.