### PR TITLE
Update Any-planet-start option locale update

### DIFF
--- a/secretas/locale/en/secretas.cfg
+++ b/secretas/locale/en/secretas.cfg
@@ -151,3 +151,5 @@ condense-level-4-modules-into-one-technology=If true, all level 4 modules will b
 check-this-if-frozeta-start=This must be set to true if in order for Frozeta start to work correctly.
 automatically-populate-science-pack-productivity-research=If true, we'll try to update science-pack-productivity research with all existing science packs. Disable if you have mod conflict.
 
+[string-mod-setting]
+aps-planet-frozeta=[planet=frozeta] Frozeta


### PR DESCRIPTION
This PR adds locale to Frozeta's Any-planet-start selector to match Muluna and vanilla planets. This is what it looks like before this PR. 
![image](https://github.com/user-attachments/assets/cfe2e0bb-0b95-4967-bc99-6e2eaea02b8a)
