### PR TITLE
Ambient sound fix

### DIFF
--- a/secretas/info.json
+++ b/secretas/info.json
@@ -4,7 +4,7 @@
     "title": "Secretas&Frozeta",
     "author": "ZDK, 2025",
     "factorio_version": "2.0",
-    "dependencies": ["base >= 2.0",
+    "dependencies": ["base >= 2.0.60",
         "space-age >= 2.0",
         "quality >= 2.0",
         "? any-planet-start >= 1.1.13"

--- a/secretas/prototypes/ambient-sounds.lua
+++ b/secretas/prototypes/ambient-sounds.lua
@@ -9,7 +9,7 @@ data:extend(
     name = "frozeta-4-hero",
     track_type = "hero-track",
     planet = "frozeta",
-    sound = "__space-age__/sound/ambient/aquilo/aquilo-4-hero.ogg", --Replaced if Factorio version >= 2.0.59
+    sound = "__space-age__/sound/ambient/aquilo/aquilo-3-hero.ogg",
   },
   require("__space-age__/sound/ambient/aquilo/aquilo-1/aquilo-1"),
   {
@@ -73,10 +73,3 @@ data:extend(
 -------------------------------------------------------------------------------------SPACE
 
 })
---[[
-local hero_sound = data.raw["ambient-sound"]["frozeta-4-hero"]
-
-if helpers.compare_versions(helpers.game_version,"2.0.59") > -1 then
-  hero_sound.sound = "__space-age__/sound/ambient/aquilo/aquilo-3-hero.ogg"
-end
---]]


### PR DESCRIPTION
Since 2.0.60 is now stable, the ambient sound aquilo-hero-4.ogg has been renamed to aquilo-hero-3.ogg, rendering the previous version of the mod unable to launch. This PR sets the oldest supported version to 2.0.60 (the most recent stable version after the sound file rename) and uses the new name for the sound file.

Closes #50 