### PR TITLE
2.0.61 fix

### DIFF
--- a/secretas/info.json
+++ b/secretas/info.json
@@ -4,8 +4,8 @@
     "title": "Secretas&Frozeta",
     "author": "ZDK, 2025",
     "factorio_version": "2.0",
-    "dependencies": ["base >= 2.0",
-        "space-age >= 2.0",
+    "dependencies": ["base >= 2.0.60",
+        "space-age",
         "quality >= 2.0",
         "? any-planet-start >= 1.1.13"
     ],

--- a/secretas/prototypes/ambient-sounds.lua
+++ b/secretas/prototypes/ambient-sounds.lua
@@ -73,10 +73,8 @@ data:extend(
 -------------------------------------------------------------------------------------SPACE
 
 })
---[[
-local hero_sound = data.raw["ambient-sound"]["frozeta-4-hero"]
 
-if helpers.compare_versions(helpers.game_version,"2.0.59") > -1 then
+local hero_sound = data.raw["ambient-sound"]["frozeta-4-hero"]
+if helpers.compare_versions(helpers.game_version,"2.0.60") > -1 then
   hero_sound.sound = "__space-age__/sound/ambient/aquilo/aquilo-3-hero.ogg"
 end
---]]

--- a/secretas/prototypes/ambient-sounds.lua
+++ b/secretas/prototypes/ambient-sounds.lua
@@ -75,6 +75,6 @@ data:extend(
 })
 
 local hero_sound = data.raw["ambient-sound"]["frozeta-4-hero"]
-if helpers.compare_versions(helpers.game_version,"2.0.60") > -1 then
+if helpers.compare_versions(helpers.game_version,"2.0.61") > -1 then
   hero_sound.sound = "__space-age__/sound/ambient/aquilo/aquilo-3-hero.ogg"
 end


### PR DESCRIPTION
This PR makes Secretas work on 2.0.61 by fixing an incorrect sound reference.
I have also raised the required version of Factorio to the latest stable. I did not do this in my last PR, which resulted in a bug when a version of Factorio before the ability to check game version was added in 2.0.55 was loaded that led to you reverting my change. This should not happen again.