### PR TITLE
Reordered technologies in a more sensible way

### DIFF
--- a/secretas/prototypes/technology.lua
+++ b/secretas/prototypes/technology.lua
@@ -43,7 +43,7 @@ if ((mods["dea-dia-system"] == false or mods["dea-dia-system"] == nil) or settin
         time = 60
       }
     },
-  
+
   })
 end
 
@@ -125,7 +125,7 @@ if (mods["dea-dia-system"] and settings.startup["ignore-dea-dia-compatibility"].
     }
 
   })
-  
+
 end
 
 
@@ -149,7 +149,7 @@ data:extend({
                 recipe = "hyper-inserter",
             },
         },
-        prerequisites = {"planet-discovery-secretas"},
+        prerequisites = {"golden-science-pack"},
         unit =
         {
           count = 1000,
@@ -233,7 +233,7 @@ data:extend({
           item = "gold-plate",
           count = 20
       },
-      prerequisites = { "planet-discovery-secretas"}
+      prerequisites = { "steam-recycler"}
     },
     {
       type = "technology",
@@ -249,7 +249,7 @@ data:extend({
               recipe = "gold-heat-pipe",
           },
       },
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack"},
       unit =
       {
         count = 3000,
@@ -275,13 +275,9 @@ data:extend({
         {
           type = "unlock-recipe",
           recipe = "gold-railgun-turret"
-        },
-        {
-          type = "unlock-recipe",
-          recipe = "railgun-ammo"
-        },
+        }
       },
-      prerequisites = {"planet-discovery-secretas","railgun"},
+      prerequisites = {"golden-science-pack","railgun"},
       unit =
       {
         count = 2000,
@@ -313,7 +309,7 @@ data:extend({
           recipe = "pentapod-egg-unrestricted"
         },
       },
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack"},
       unit =
       {
         count = 2000,
@@ -346,7 +342,7 @@ data:extend({
         },
 
       },
-      prerequisites = {"transport-belt-capacity-2","planet-discovery-secretas"},
+      prerequisites = {"transport-belt-capacity-2","golden-science-pack"},
       unit =
       {
         count = 6000,
@@ -382,7 +378,7 @@ data:extend({
           modifier = 1
         }
       },
-      prerequisites = {"worker-robots-storage-3", "planet-discovery-secretas"},
+      prerequisites = {"worker-robots-storage-3", "golden-science-pack"},
       unit =
       {
         count = 900,
@@ -558,7 +554,7 @@ data:extend({
           change = 0.1
         }
       },
-      prerequisites = {"planet-discovery-secretas", "production-science-pack"},
+      prerequisites = {"golden-science-pack", "production-science-pack"},
       unit =
       {
         count_formula = "2^L*600",
@@ -653,9 +649,9 @@ data:extend({
           change = 0.01
         },
 
-        
+
       },
-      prerequisites = {"promethium-science-pack","planet-discovery-secretas"},
+      prerequisites = {"promethium-science-pack","golden-science-pack"},
       unit =
       {
         count_formula = "1.5^L*1200",
@@ -699,7 +695,7 @@ data:extend({
           change = 0.07,
         }
       },
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack"},
       unit =
       {
         count_formula = "1.5^L*1000",
@@ -732,7 +728,7 @@ if(settings.startup["condense-level-4-modules-into-one-technology"].value) then
       name = "module-finale",
       icons = util.technology_icon_constant_recipe_productivity("__secretas__/graphics/technology/module.png"),
       icon_size = 256,
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack", "quality-module-3", "productivity-module-3", "efficiency-module-3", "speed-module-3"},
       effects =
       {
           {
@@ -785,7 +781,7 @@ else
       name = "quality-module-4-S",
       icons = util.technology_icon_constant_recipe_productivity("__secretas__/graphics/technology/quality-module-4-tech.png"),
       icon_size = 256,
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack", "quality-module-3"},
       effects =
       {
           {
@@ -818,7 +814,7 @@ else
       name = "efficiency-module-4-S",
       icons = util.technology_icon_constant_recipe_productivity("__secretas__/graphics/technology/efficiency-module-4-tech.png"),
       icon_size = 256,
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack", "efficiency-module-3"},
       effects =
       {
           {
@@ -851,7 +847,7 @@ else
       name = "speed-module-4-S",
       icons = util.technology_icon_constant_recipe_productivity("__secretas__/graphics/technology/speed-module-4-tech.png"),
       icon_size = 256,
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack", "speed-module-3"},
       effects =
       {
           {
@@ -884,7 +880,7 @@ else
       name = "productivity-module-4-S",
       icons = util.technology_icon_constant_recipe_productivity("__secretas__/graphics/technology/productivity-module-4-tech.png"),
       icon_size = 256,
-      prerequisites = {"planet-discovery-secretas"},
+      prerequisites = {"golden-science-pack", "productivity-module-3"},
       effects =
       {
           {


### PR DESCRIPTION
Made it more like on other planets.  Land -> Collect something -> Unlock science via trigger -> Craft science and unlock everything else. (also removed railgun ammo as a reward since it's already unlocked at this stage)